### PR TITLE
`try/except` for Vertex Information

### DIFF
--- a/src/flow2supera/reader.py
+++ b/src/flow2supera/reader.py
@@ -216,10 +216,16 @@ class InputReader:
         interaction.idx = int(ixn_idx)
         interaction.interaction_id = int(ixn['vertex_id']) 
         interaction.target = int(ixn['target'])
-        interaction.x = ixn['vertex'][0]
-        interaction.y = ixn['vertex'][1]
-        interaction.z = ixn['vertex'][2]
-        interaction.time = ixn['vertex'][3]
+        try:
+            interaction.x = ixn['vertex'][0]
+            interaction.y = ixn['vertex'][1]
+            interaction.z = ixn['vertex'][2]
+            interaction.time = ixn['vertex'][3]
+        except ValueError:
+            interaction.x = ixn['x_vert']
+            interaction.y = ixn['y_vert']
+            interaction.z = ixn['z_vert']
+            interaction.time = ixn['t_vert']
         interaction.pdg_code = int(ixn['nu_pdg'])
         interaction.lepton_pdg_code = int(ixn['lep_pdg'])  
         interaction.energy_init = ixn['Enu']


### PR DESCRIPTION
When trying to run `bin/run_flow2supera.py` on NDLAr simulation using the latest and greatest software, I ran into the following error:

```
----- [run_supera] Processing Entry 0 -----

Traceback (most recent call last):
  File "install/flow2supera/bin/run_flow2supera.py", line 53, in <module>
    flow2supera.utils.run_supera(out_file=data.output_filename,
  File "/pscratch/sd/d/dunepro/abooth/install/MicroProdN4p1/ND_Production/run-mlreco/install/flow2supera/src/flow2supera/utils.py", line 255, in run_supera
    input_data = reader.GetEntry(entry)
  File "/pscratch/sd/d/dunepro/abooth/install/MicroProdN4p1/ND_Production/run-mlreco/install/flow2supera/src/flow2supera/reader.py", line 425, in GetEntry
    interaction = self.GetNeutrinoIxn(ixn, ixn_idx)
  File "/pscratch/sd/d/dunepro/abooth/install/MicroProdN4p1/ND_Production/run-mlreco/install/flow2supera/src/flow2supera/reader.py", line 215, in GetNeutrinoIxn
    interaction.x = ixn['vertex'][0]
ValueError: no field of name vertex
```

[This commit](https://github.com/DUNE/ND_Production/commit/711550b2efac5a9495bd4938615e68a753011e75) on March 22nd 2024 in the script doing edep-root to edep-h5 conversion changes how the vertex information is stored. 2x2 production confirmed that the simulation that they have been using was "converted" before this date which is why this hasn't come up already. Since we are actively using simulation made on both side of this commit, we should cover both cases.